### PR TITLE
Another implementation of explicit waiter

### DIFF
--- a/explicitWaiter.js
+++ b/explicitWaiter.js
@@ -24,7 +24,10 @@ const implicitWaitTime = browser.params.implicitWaitTimeout || 0;
 browser.explWait = function (predicate, timeout, message) {
     return browser.manage().timeouts().implicitlyWait(0).then(()=> {
         return browser.wait(predicate, timeout, message)
-            .then(undefined,
+            .then(
+                ()=>{
+                    browser.manage().timeouts().implicitlyWait(implicitWaitTime)
+                },
                 (err)=> {
                     browser.manage().timeouts().implicitlyWait(implicitWaitTime)
                     throw err


### PR DESCRIPTION
Own implementation of implicit wait setting before and after wait

Differences 

1) `explWait` - now is a function of browser object, not ElementFinder

2) Same set and same parameters types as in original browser.wait

3) Staring wait only after implicitWait as actually set (thru .then() callback), this insures that we will not start waiting until implicit wait is in 0 state.

4) Throwing same errors as original browser.wait would throw.

5) Less code, familiar function usage